### PR TITLE
removed plans from readme. plans now in new branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,3 @@ Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-Front End Planning
-https://miro.com/app/board/uXjVNxQ_ai8=/?share_link_id=201790811205


### PR DESCRIPTION
Link to my plans are in the readme. Exporting as an image was really blurry so i shared the link instead.
Plans are ongoing and not finalised. These are ideas to build upon and add to as i start fleshing out the project.